### PR TITLE
Clarify quickstart and guide docs

### DIFF
--- a/calibration.rst
+++ b/calibration.rst
@@ -9,14 +9,32 @@ as the fallback for any uncalibrated op.
 Using a calibrated model
 -------------------------
 
+Use the same hardware configuration you would pass to ``simulate`` or ``estimate_memory``, including
+its topology. The calibration-specific parameter is:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Parameter
+     - Meaning
+   * - ``calibrated_model``
+     - Path to a directory containing fitted tree models. Passing this value makes SysSim load and
+       use ``TreeEstimator`` automatically.
+
 .. code-block:: python
 
-   from syssim.compute.tree_estimator import TreeEstimator
    from syssim import HardwareConfig
 
    hw = HardwareConfig(
        peak_tflops_mm=1979, peak_tflops_math=989,
        peak_memory_bandwidth_GBps=3350, gpus_per_node=4,
+       topology={
+           "dims": ["fully_connected"],
+           "size": [4],
+           "bandwidth": [450],
+           "latency": [12000],
+       },
        calibrated_model="data/gh200",   # directory with fitted trees
    )
 

--- a/concepts.rst
+++ b/concepts.rst
@@ -8,6 +8,10 @@ SysSim traces an LLM training step into an **operator graph**, attributes a time
 each operator, and runs a discrete-event simulation over the cluster topology — no real computation
 or weights are needed.
 
+Tracing still requires PyTorch CUDA dispatch: SysSim uses PyTorch fake tensors marked with
+``device="cuda"`` so PyTorch builds the same operator graph shape it would use for CUDA tensors,
+without running the real kernels.
+
 Parallelism
 -----------
 
@@ -49,7 +53,28 @@ learned per-operator residual — see :doc:`calibration`.
 Reading the report
 -------------------
 
-:func:`simulate` returns a :class:`SimulationReport`:
+:func:`simulate` returns a :class:`SimulationReport`; the ``syssim run`` CLI prints the same core
+fields. A typical report looks like:
+
+.. code-block:: text
+
+   SimulationReport(
+     step_time_ms        = 644.6507
+       forward_ms        = 184.5179
+       backward_ms       = 383.1765
+       optimizer_ms      = 39.4327
+     collective_total_ms = 53.9978
+     collective_exposed  = 37.5235
+     achieved_tflops     = 184.55
+     mfu                 = 9.33%
+     hfu                 = 12.43%
+     peak_memory_gb      = 26.133
+     Bottlenecks(
+       dominant_op_type = math
+       top_ops_by_time  = [('optimizer_step_4289', 39.43271286447761), ('op_1181_aten.mm', 4.286653309549106), ('op_1182_aten.mm', 4.21173467212024)]
+       peak_module      = Float16Module
+     )
+   )
 
 .. list-table::
    :header-rows: 1
@@ -64,7 +89,7 @@ Reading the report
    * - ``collective_total_ms`` / ``collective_exposed_ms``
      - Total vs. non-overlapped collective time.
    * - ``achieved_tflops``, ``mfu``, ``hfu``
-     - Throughput and model/hardware FLOPs utilization.
+     - Throughput, Model FLOPs Utilization (MFU), and Hardware FLOPs Utilization (HFU).
    * - ``peak_memory_gb``
      - Peak per-GPU memory (heaviest pipeline stage).
    * - ``pp_stage_memory_gb``

--- a/install.rst
+++ b/install.rst
@@ -5,8 +5,10 @@ Requirements
 ------------
 
 - **Python 3.10+**
-- A working PyTorch install (``torch >= 2.6``). For *simulation* no GPU is required; a GPU is only
-  needed to *profile* real layers when building a calibrated estimator.
+- A working PyTorch install (``torch >= 2.6``).
+- A CUDA-capable GPU for tracing and simulation. SysSim uses PyTorch fake tensors marked with
+  ``device="cuda"``, so PyTorch still needs CUDA kernel dispatch to build the operator graph.
+  Profiling real layers for a calibrated estimator also needs GPUs.
 
 SysSim depends on ``torch``, ``megatron-core``, ``megatron-bridge``, ``numpy``, ``pandas``,
 ``pyarrow``, ``pyyaml``, ``scikit-learn``, ``lightgbm``, and ``transformers`` (installed
@@ -29,4 +31,5 @@ Verify
    syssim --help
 
 You should see the ``run``, ``memory``, ``summary``, ``sweep``, ``profile``, and ``calibrate``
-subcommands. Continue to :doc:`quickstart`.
+subcommands. ``run`` is the CLI name for the full ``simulate`` mode. Continue to
+:doc:`quickstart`.

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -1,14 +1,33 @@
 Quickstart
 ==========
 
-This walks through a single simulation of **Qwen3-1.7B** on a 4-GPU **GH200** node, using the
-example configs shipped in the SysSim repo.
+This walks through **Qwen3-1.7B** on a 4-GPU **GH200** node, using the example configs shipped in
+the SysSim repo.
+
+Choose a mode
+-------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Mode
+     - Use it when you want to
+     - Output to inspect
+   * - ``simulate``
+     - Run the full training-step simulator.
+     - Step time, MFU, memory, OOM status, and bottlenecks.
+   * - ``estimate_memory``
+     - Check whether a configuration fits in GPU memory without running the runtime simulator.
+     - Peak per-GPU memory and per-pipeline-stage memory.
+   * - ``sweep``
+     - Try several values for one or more config axes.
+     - One report per candidate plus ``best(metric)``. The best row is the one with the largest
+       selected metric, so the quickstart uses ``mfu`` to select the highest-MFU candidate.
 
 Python API
 ----------
 
-Three entry points cover the common needs — run a full simulation, check memory only, or sweep a
-config axis.
+The Python API exposes the same three modes.
 
 .. tab-set::
 
@@ -19,7 +38,7 @@ config axis.
          import syssim
 
          MODEL = "examples/configs/models/qwen3-1_7b.yaml"
-         HW    = "examples/configs/hardware/isambard_gh200_4gpu.yaml"
+         HW = "examples/configs/hardware/isambard_gh200_4gpu.yaml"
 
          report = syssim.simulate(
              model=MODEL, hardware=HW,
@@ -34,9 +53,11 @@ config axis.
 
          import syssim
 
+         MODEL = "examples/configs/models/qwen3-1_7b.yaml"
+         HW = "examples/configs/hardware/isambard_gh200_4gpu.yaml"
+
          mem = syssim.estimate_memory(
-             model="examples/configs/models/qwen3-1_7b.yaml",
-             hardware="examples/configs/hardware/isambard_gh200_4gpu.yaml",
+             model=MODEL, hardware=HW,
              parallelism=syssim.ParallelismConfig(tp=2, dp=2),
              training=syssim.TrainingConfig(micro_batch=1, global_batch=8, dtype="bf16"),
          )
@@ -48,9 +69,11 @@ config axis.
 
          import syssim
 
+         MODEL = "examples/configs/models/qwen3-1_7b.yaml"
+         HW = "examples/configs/hardware/isambard_gh200_4gpu.yaml"
+
          result = syssim.sweep(
-             model="examples/configs/models/qwen3-1_7b.yaml",
-             hardware="examples/configs/hardware/isambard_gh200_4gpu.yaml",
+             model=MODEL, hardware=HW,
              parallelism=syssim.ParallelismConfig(),
              training=syssim.TrainingConfig(micro_batch=1, global_batch=8, dtype="bf16"),
              over={"parallelism.tp": [1, 2, 4]},
@@ -61,25 +84,44 @@ config axis.
 Command line
 ------------
 
-The same three workflows are available from the ``syssim`` CLI:
+The same three workflows are available from the ``syssim`` CLI.
 
-.. code-block:: bash
+For CLI commands, the first positional argument is the model YAML and ``--hardware`` points to the
+hardware YAML.
 
-   # Full report (step time, MFU, memory, bottlenecks)
-   syssim run examples/configs/models/qwen3-1_7b.yaml \
-       --hardware examples/configs/hardware/isambard_gh200_4gpu.yaml \
-       --tp 2 --dp 2 --micro-batch 1 --global-batch 8
+.. tab-set::
 
-   # Memory only
-   syssim memory examples/configs/models/qwen3-1_7b.yaml \
-       --hardware examples/configs/hardware/isambard_gh200_4gpu.yaml \
-       --micro-batch 1 --global-batch 8
+   .. tab-item:: simulate
 
-   # Sweep an axis, pick the best by a metric
-   syssim sweep examples/configs/models/qwen3-1_7b.yaml \
-       --hardware examples/configs/hardware/isambard_gh200_4gpu.yaml \
-       --micro-batch 1 --global-batch 8 \
-       --over parallelism.tp=1,2,4 --metric mfu
+      Full simulation report: step time, MFU, memory, OOM status, and bottlenecks. The CLI
+      subcommand for this mode is ``run``.
+
+      .. code-block:: bash
+
+         syssim run examples/configs/models/qwen3-1_7b.yaml \
+             --hardware examples/configs/hardware/isambard_gh200_4gpu.yaml \
+             --tp 2 --dp 2 --micro-batch 1 --global-batch 8
+
+   .. tab-item:: memory
+
+      Memory-only report. This skips runtime simulation and is useful for fit checks.
+
+      .. code-block:: bash
+
+         syssim memory examples/configs/models/qwen3-1_7b.yaml \
+             --hardware examples/configs/hardware/isambard_gh200_4gpu.yaml \
+             --tp 2 --dp 2 --micro-batch 1 --global-batch 8
+
+   .. tab-item:: sweep
+
+      Sweep tensor parallelism values and select the candidate with the highest ``mfu``.
+
+      .. code-block:: bash
+
+         syssim sweep examples/configs/models/qwen3-1_7b.yaml \
+             --hardware examples/configs/hardware/isambard_gh200_4gpu.yaml \
+             --micro-batch 1 --global-batch 8 \
+             --over parallelism.tp=1,2,4 --metric mfu
 
 Next steps
 ----------


### PR DESCRIPTION
## Summary
- Split quickstart examples by simulate, memory, and sweep modes for both Python and CLI
- Clarify setup requirements, example paths, model/hardware YAML arguments, and CLI `run` naming
- Add guide context for CUDA-dispatched fake tensors, MFU/HFU names, report output, and calibrated model usage

## Verification
- `.docsenv/bin/sphinx-build -b html . _build/html`
- `git diff --check`