### PR TITLE
Document vendor-neutral hardware targets

### DIFF
--- a/concepts.rst
+++ b/concepts.rst
@@ -8,9 +8,10 @@ SysSim traces an LLM training step into an **operator graph**, attributes a time
 each operator, and runs a discrete-event simulation over the cluster topology — no real computation
 or weights are needed.
 
-Tracing still requires PyTorch CUDA dispatch: SysSim uses PyTorch fake tensors marked with
-``device="cuda"`` so PyTorch builds the same operator graph shape it would use for CUDA tensors,
-without running the real kernels.
+Tracing still requires a PyTorch GPU backend exposed through ``torch.cuda``. SysSim uses PyTorch
+fake tensors marked with ``device="cuda"`` so PyTorch builds the same operator graph shape it would
+use for GPU tensors, without running the real kernels. On AMD systems, PyTorch ROCm/HIP builds reuse
+the same ``torch.cuda`` interface.
 
 Parallelism
 -----------

--- a/concepts.rst
+++ b/concepts.rst
@@ -10,8 +10,8 @@ or weights are needed.
 
 Tracing still requires a PyTorch GPU backend exposed through ``torch.cuda``. SysSim uses PyTorch
 fake tensors marked with ``device="cuda"`` so PyTorch builds the same operator graph shape it would
-use for GPU tensors, without running the real kernels. On AMD systems, PyTorch ROCm/HIP builds reuse
-the same ``torch.cuda`` interface.
+use for GPU tensors, without running the real kernels. This is a PyTorch interface requirement; the
+hardware model itself is provided separately through the hardware YAML.
 
 Parallelism
 -----------

--- a/configuration.rst
+++ b/configuration.rst
@@ -62,6 +62,34 @@ A multi-level fabric (e.g. intra-node NVLink + inter-node Slingshot) adds a seco
 list. The number of nodes is derived from ``world_size / gpus_per_node``. See
 :class:`HardwareConfig` for every field.
 
+Other accelerator vendors
+-------------------------
+
+Hardware targets are vendor-neutral. To simulate another accelerator family, provide that device's
+compute peaks, memory bandwidth, HBM capacity, and topology. For example, an AMD MI300-style target
+uses the same schema:
+
+.. code-block:: yaml
+
+   # examples/configs/hardware/amd_mi300_8gpu.yaml
+   peak_tflops_mm: 653             # tensor-unit peak (TFLOP/s)
+   peak_tflops_math: 326.5         # vector/math peak (TFLOP/s)
+   peak_memory_bandwidth_GBps: 5200
+
+   gpus_per_node: 8
+   gpu_memory_GB: 192              # set to the HBM capacity of the target card
+
+   topology:
+     dims:      [ fully_connected ]   # choose fully_connected | switch | ring to match the fabric
+     size:      [ 8 ]
+     bandwidth: [ 300 ]               # replace with measured per-GPU uni-directional GB/s
+     latency:   [ 12000 ]             # replace with measured latency (ns)
+
+Only the hardware YAML changes; the model YAML, parallelism config, and training config stay the
+same. The default roofline estimator uses these hardware peaks directly. For higher accuracy on a
+specific accelerator, build a calibrated estimator for that device and set ``calibrated_model`` in
+the hardware YAML.
+
 Parallelism & training knobs
 -----------------------------
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -62,12 +62,15 @@ A multi-level fabric (e.g. intra-node NVLink + inter-node Slingshot) adds a seco
 list. The number of nodes is derived from ``world_size / gpus_per_node``. See
 :class:`HardwareConfig` for every field.
 
-Other accelerator vendors
--------------------------
+Generic accelerator targets
+---------------------------
 
-Hardware targets are vendor-neutral. To simulate another accelerator family, provide that device's
-compute peaks, memory bandwidth, HBM capacity, and topology. For example, an AMD MI300-style target
-uses the same schema:
+SysSim hardware targets are described by capabilities, not by vendor-specific code paths. The same
+model, parallelism, and training configuration can be evaluated against any accelerator-like target
+once you provide the target's compute peaks, memory bandwidth, HBM capacity, and communication
+topology.
+
+AMD is one example of this generic path. An MI300-style target uses the same hardware YAML schema:
 
 .. code-block:: yaml
 
@@ -86,9 +89,9 @@ uses the same schema:
      latency:   [ 12000 ]             # replace with measured latency (ns)
 
 Only the hardware YAML changes; the model YAML, parallelism config, and training config stay the
-same. The default roofline estimator uses these hardware peaks directly. For higher accuracy on a
-specific accelerator, build a calibrated estimator for that device and set ``calibrated_model`` in
-the hardware YAML.
+same. The default roofline estimator uses the supplied peaks directly, regardless of vendor. For
+higher accuracy on a specific accelerator, build a calibrated estimator for that device and set
+``calibrated_model`` in the hardware YAML.
 
 Parallelism & training knobs
 -----------------------------

--- a/install.rst
+++ b/install.rst
@@ -8,7 +8,7 @@ Requirements
 - A working PyTorch install (``torch >= 2.6``).
 - A PyTorch GPU backend exposed through ``torch.cuda`` for tracing and simulation. SysSim uses
   PyTorch fake tensors marked with ``device="cuda"``, so PyTorch still needs GPU dispatch to build
-  the operator graph. This interface is used by NVIDIA CUDA and by AMD ROCm/HIP builds of PyTorch.
+  the operator graph. Any GPU backend supported through that PyTorch interface can be used.
   Profiling real layers for a calibrated estimator also needs GPUs.
 
 SysSim depends on ``torch``, ``megatron-core``, ``megatron-bridge``, ``numpy``, ``pandas``,

--- a/install.rst
+++ b/install.rst
@@ -6,10 +6,10 @@ Requirements
 
 - **Python 3.10+**
 - A working PyTorch install (``torch >= 2.6``).
-- A PyTorch GPU backend exposed through ``torch.cuda`` for tracing and simulation. This can be
-  NVIDIA CUDA or AMD ROCm/HIP through PyTorch's CUDA-compatible interface. SysSim uses PyTorch fake
-  tensors marked with ``device="cuda"``, so PyTorch still needs GPU dispatch to build the operator
-  graph. Profiling real layers for a calibrated estimator also needs GPUs.
+- A PyTorch GPU backend exposed through ``torch.cuda`` for tracing and simulation. SysSim uses
+  PyTorch fake tensors marked with ``device="cuda"``, so PyTorch still needs GPU dispatch to build
+  the operator graph. This interface is used by NVIDIA CUDA and by AMD ROCm/HIP builds of PyTorch.
+  Profiling real layers for a calibrated estimator also needs GPUs.
 
 SysSim depends on ``torch``, ``megatron-core``, ``megatron-bridge``, ``numpy``, ``pandas``,
 ``pyarrow``, ``pyyaml``, ``scikit-learn``, ``lightgbm``, and ``transformers`` (installed

--- a/install.rst
+++ b/install.rst
@@ -6,9 +6,10 @@ Requirements
 
 - **Python 3.10+**
 - A working PyTorch install (``torch >= 2.6``).
-- A CUDA-capable GPU for tracing and simulation. SysSim uses PyTorch fake tensors marked with
-  ``device="cuda"``, so PyTorch still needs CUDA kernel dispatch to build the operator graph.
-  Profiling real layers for a calibrated estimator also needs GPUs.
+- A PyTorch GPU backend exposed through ``torch.cuda`` for tracing and simulation. This can be
+  NVIDIA CUDA or AMD ROCm/HIP through PyTorch's CUDA-compatible interface. SysSim uses PyTorch fake
+  tensors marked with ``device="cuda"``, so PyTorch still needs GPU dispatch to build the operator
+  graph. Profiling real layers for a calibrated estimator also needs GPUs.
 
 SysSim depends on ``torch``, ``megatron-core``, ``megatron-bridge``, ``numpy``, ``pandas``,
 ``pyarrow``, ``pyyaml``, ``scikit-learn``, ``lightgbm``, and ``transformers`` (installed


### PR DESCRIPTION
## Summary
- Add an AMD MI300-style hardware YAML example using the existing vendor-neutral hardware schema
- Clarify that other accelerator vendors are modeled by swapping hardware peaks, memory, topology, and optional calibrated models
- Update tracing requirements to describe PyTorch GPU backends exposed through `torch.cuda`, including ROCm/HIP

## Verification
- `.docsenv/bin/sphinx-build -b html . _build/html`
- `git diff --check`